### PR TITLE
Add new line after warning message

### DIFF
--- a/bdb/drivers/postgres.go
+++ b/bdb/drivers/postgres.go
@@ -311,7 +311,7 @@ func (p *PostgresDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 				c.DBType = "hstore"
 			} else {
 				c.Type = "string"
-				fmt.Printf("Warning: Incompatible data type detected: %s", c.UDTName)
+				fmt.Printf("Warning: Incompatible data type detected: %s\n", c.UDTName)
 			}
 		default:
 			c.Type = "null.String"
@@ -348,7 +348,7 @@ func (p *PostgresDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 				c.DBType = "hstore"
 			} else {
 				c.Type = "string"
-				fmt.Printf("Warning: Incompatible data type detected: %s", c.UDTName)
+				fmt.Printf("Warning: Incompatible data type detected: %s\n", c.UDTName)
 			}
 		default:
 			c.Type = "string"


### PR DESCRIPTION
When multiple incompatible data type warnings are emitted, it's hard to read the type name since there's no white space between the errors. This adds a new line to the end of each warning.